### PR TITLE
Change Math.round() to Math.floor() to fix rounding errors

### DIFF
--- a/src/hooks/useRunningGame.ts
+++ b/src/hooks/useRunningGame.ts
@@ -14,7 +14,7 @@ export const useRunningGame = ({ displayLog }: { displayLog?: boolean }) => {
   function onGameInfoUpdated(payload: overwolf.games.GameInfoUpdatedEvent) {
     const gameRunning: UseRunningGamePayload = {
       gameRunning: payload?.gameInfo?.isRunning ?? false,
-      id: Math.round((payload?.gameInfo?.id || 0) / 10),
+      id: Math.floor((payload?.gameInfo?.id || 0) / 10),
       title: payload?.gameInfo?.title || '',
       gameChanged: payload?.gameChanged || false,
       isInFocus: payload?.focusChanged || false,
@@ -38,7 +38,7 @@ export const useRunningGame = ({ displayLog }: { displayLog?: boolean }) => {
       )
     setGame((currentGame) => ({
       gameChanged: currentGame?.gameChanged || false,
-      id: Math.round((payload?.id || 0) / 10),
+      id: Math.floor((payload?.id || 0) / 10),
       title: payload?.title || '',
       gameRunning: payload?.isRunning ?? false,
       isInFocus: payload?.isInFocus ?? false,


### PR DESCRIPTION
Math.round() causes certain game ID's to be incorrect after calculation. In my case that is League of Legends, which when launched has an ID of 54267, this gets rounded up after being divided by 10 and ends up at 5427, which is not a valid game ID to get game events for. I changed it to Math.floor() since that is what Overwolf does in official documentation (https://overwolf.github.io/docs/api/games-ids#game-id-and-instance-id)